### PR TITLE
[TH2-4035] Refactor API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,20 @@ Important: Changes won’t be committed unless the conversion of every resource 
 
 __Returns:__
 
-`ConverterControllerResponse` object.
+`ConversionSummary` object.
 
 ```kotlin
-class ConverterControllerResponse(
-    val convertedResources: MutableList<String> = ArrayList(),
-    val errorMessages: MutableList<ErrorMessage> = ArrayList(),
-    var commitRef: String? = null
+class ConversionSummary(
+    val convertedResourceNames: MutableList<String>,
+    val errorMessages: MutableList<ErrorMessage>,
+    var commitRef: String?
 )
 ```
 __response will contain:__ 
 
-list of resources that were converted (if any)
+names of resources that were converted (if any)
 
-list of errors encountered during conversion (if any)
+errors encountered during conversion (if any)
 
 commit reference hash (if there were any changes, and push was successful)
 
@@ -42,7 +42,7 @@ __Response body example:__
 
 ```json
 {
-  "convertedResources": [
+  "convertedResourceNames": [
     "fix-client",
     "rpt-data-viewer",
     "rpt-data-provider",
@@ -78,20 +78,20 @@ Important: New schema/branch won’t be made, changes won’t be committed and k
 
 __Returns__:
 
-`ConverterControllerResponse` object.
+`ConversionSummary` object.
 
 __response will contain:__
 
-list of resources that were converted (if any)
+names of resources that were converted (if any)
 
-list of errors encountered during conversion (if any)
+errors encountered during conversion (if any)
 
 commit reference hash (if there were any changes, and push was successful)
 
 __Response body example:__
 ```json
 {
-    "convertedResources": [
+    "convertedResourceNames": [
         "recon",
         "mstore",
         "script",
@@ -169,50 +169,66 @@ Example:
 
 __Returns:__
 
-List of converted `Th2Resource` objects.
+`ConversionResult` object.
 
-*Note:* You can convert JSON format to YAML with [this online tool](https://onlineyamltools.com/convert-json-to-yaml), and make it more readable with [linter](http://www.yamllint.com/) if necessary.  
+```kotlin
+class ConversionResult(
+    val summary: ConversionSummary,
+    val convertedResources: List<Th2Resource>
+)
+```
 
 __Response body example:__
 
 ```json
-[
+{
+  "summary": {
+    "convertedResourceNames": [
+      "script"
+    ],
+    "errorMessages": []
+  },
+  "convertedResources": [
     {
-        "apiVersion": "th2.exactpro.com/v2",
-        "kind": "Th2Box",
-        "metadata": {
-            "name": "script"
+      "apiVersion": "th2.exactpro.com/v2",
+      "kind": "Th2Box",
+      "metadata": {
+        "name": "script"
+      },
+      "spec": {
+        "imageName": "dev-script",
+        "imageVersion": "dev-script",
+        "type": "th2-script",
+        "extendedSettings": {
+          "externalBox": {
+            "enabled": true
+          },
+          "service": {
+            "enabled": false
+          }
         },
-        "spec": {
-            "imageName": "dev-script",
-            "imageVersion": "dev-script",
-            "type": "th2-script",
-            "extendedSettings": {
-                "externalBox": {
-                    "enabled": true
-                },
-                "service": {
-                    "enabled": false
-                }
-            },
-            "pins": {
-                "grpc": {
-                    "client": [
-                        {
-                            "name": "to_act",
-                            "serviceClass": "com.exactpro.th2.act.grpc.ActService"
-                        },
-                        {
-                            "name": "to_check1",
-                            "serviceClass": "com.exactpro.th2.check1.grpc.Check1Service"
-                        }
-                    ]
-                }
-            }
+        "pins": {
+          "grpc": {
+            "client": [
+              {
+                "name": "to_act",
+                "serviceClass": "com.exactpro.th2.act.grpc.ActService"
+              },
+              {
+                "name": "to_check1",
+                "serviceClass": "com.exactpro.th2.check1.grpc.Check1Service"
+              }
+            ]
+          }
         }
+      }
     }
-]
+  ]
+}
 ```
+
+*Note:* You can convert JSON format to YAML with [this online tool](https://onlineyamltools.com/convert-json-to-yaml), and make it more readable with [linter](http://www.yamllint.com/) if necessary.  
+
 
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@
 
 kotlin.code.style=official
 
-release_version=0.2.0
+release_version=0.3.0
 
 kotlin_version=1.6.21
 kotlin_detekt_version=1.20.0

--- a/src/main/kotlin/com/exactpro/th2/converter/controllers/ConverterController.kt
+++ b/src/main/kotlin/com/exactpro/th2/converter/controllers/ConverterController.kt
@@ -18,7 +18,6 @@ package com.exactpro.th2.converter.controllers
 
 import com.exactpro.th2.converter.config.ApplicationConfig
 import com.exactpro.th2.converter.controllers.errors.NotAcceptableException
-import com.exactpro.th2.converter.model.Th2Resource
 import com.exactpro.th2.converter.util.Converter.convertFromGit
 import com.exactpro.th2.converter.util.Converter.convertFromRequest
 import com.exactpro.th2.converter.util.ProjectConstants
@@ -44,13 +43,13 @@ class ConverterController {
     fun convertInSameBranch(
         @PathVariable schemaName: String,
         @PathVariable targetVersion: String
-    ): ConverterControllerResponse {
+    ): ConversionSummary {
 
         checkRequestedVersion(targetVersion)
         val gitterContext = GitterContext.getContext(ApplicationConfig.git)
         checkSourceSchema(schemaName, gitterContext)
         val conversionResult = convertFromGit(schemaName, targetVersion, gitterContext)
-        val currentResponse = conversionResult.response
+        val currentResponse = conversionResult.summary
         if (currentResponse.hasErrors()) {
             return currentResponse
         }
@@ -63,7 +62,7 @@ class ConverterController {
         } finally {
             gitter.unlock()
         }
-        return conversionResult.response
+        return conversionResult.summary
     }
 
     @PostMapping("convert/{sourceSchemaName}/{newSchemaName}/{targetVersion}")
@@ -71,13 +70,13 @@ class ConverterController {
         @PathVariable sourceSchemaName: String,
         @PathVariable newSchemaName: String,
         @PathVariable targetVersion: String
-    ): ConverterControllerResponse {
+    ): ConversionSummary {
 
         checkRequestedVersion(targetVersion)
         val gitterContext: GitterContext = GitterContext.getContext(ApplicationConfig.git)
         checkSourceSchema(sourceSchemaName, gitterContext)
         val conversionResult = convertFromGit(sourceSchemaName, targetVersion, gitterContext)
-        val currentResponse = conversionResult.response
+        val currentResponse = conversionResult.summary
         if (currentResponse.hasErrors()) {
             return currentResponse
         }
@@ -103,14 +102,14 @@ class ConverterController {
         } finally {
             newBranchGitter.unlock()
         }
-        return conversionResult.response
+        return conversionResult.summary
     }
 
     @GetMapping("convert/{targetVersion}")
     fun convertRequestedResources(
         @PathVariable targetVersion: String,
         @RequestBody resources: Set<RepositoryResource>
-    ): List<Th2Resource> {
+    ): ConversionResult {
         checkRequestedVersion(targetVersion)
         return convertFromRequest(targetVersion, resources)
     }

--- a/src/main/kotlin/com/exactpro/th2/converter/controllers/Response.kt
+++ b/src/main/kotlin/com/exactpro/th2/converter/controllers/Response.kt
@@ -16,8 +16,10 @@
 
 package com.exactpro.th2.converter.controllers
 
-data class ConverterControllerResponse(
-    val convertedResources: MutableList<String> = ArrayList(),
+import com.exactpro.th2.converter.model.Th2Resource
+
+data class ConversionSummary(
+    val convertedResourceNames: MutableList<String> = ArrayList(),
     val errorMessages: MutableList<ErrorMessage> = ArrayList(),
     var commitRef: String? = null
 ) {
@@ -26,6 +28,11 @@ data class ConverterControllerResponse(
         return errorMessages.size > 0
     }
 }
+
+data class ConversionResult(
+    val summary: ConversionSummary,
+    val convertedResources: List<Th2Resource>
+)
 
 data class ErrorMessage(
     val resourceName: String,

--- a/src/main/kotlin/com/exactpro/th2/converter/util/LinksInserter.kt
+++ b/src/main/kotlin/com/exactpro/th2/converter/util/LinksInserter.kt
@@ -16,7 +16,7 @@
 
 package com.exactpro.th2.converter.util
 
-import com.exactpro.th2.converter.controllers.ConverterControllerResponse
+import com.exactpro.th2.converter.controllers.ConversionSummary
 import com.exactpro.th2.converter.controllers.ErrorMessage
 import com.exactpro.th2.converter.model.Th2Resource
 import com.exactpro.th2.converter.model.latest.box.GenericBoxSpec
@@ -103,8 +103,8 @@ class LinksInserter {
         val multipleDictionary: MutableList<MultiDictionary> = ArrayList()
     )
 
-    fun addErrorsToResponse(response: ConverterControllerResponse) {
-        response.errorMessages.addAll(errors)
+    fun addErrorsToSummary(summary: ConversionSummary) {
+        summary.errorMessages.addAll(errors)
     }
 
     fun insertLinksIntoBoxes(convertedResources: List<Th2Resource>, links: Set<RepositoryResource>) {

--- a/src/main/kotlin/com/exactpro/th2/converter/util/RepositoryUtils.kt
+++ b/src/main/kotlin/com/exactpro/th2/converter/util/RepositoryUtils.kt
@@ -16,6 +16,7 @@
 
 package com.exactpro.th2.converter.util
 
+import com.exactpro.th2.converter.controllers.ConversionResult
 import com.exactpro.th2.converter.controllers.errors.NotAcceptableException
 import com.exactpro.th2.converter.controllers.errors.ServiceException
 import com.exactpro.th2.infrarepo.InconsistentRepositoryStateException
@@ -47,7 +48,7 @@ object RepositoryUtils {
                     )
                 )
             }
-            conversionResult.response.commitRef = gitter.commitAndPush("Schema conversion")
+            conversionResult.summary.commitRef = gitter.commitAndPush("Schema conversion")
         } catch (irse: InconsistentRepositoryStateException) {
             handleInconsistentRepoState(gitter, irse)
         } catch (e: Exception) {

--- a/src/test/kotlin/ConverterTest.kt
+++ b/src/test/kotlin/ConverterTest.kt
@@ -78,7 +78,9 @@ internal class ConverterTest {
      */
     @Test
     fun testPinsConversionToV2FromRequest() {
-        val convertedTh2ResList = Converter.convertFromRequest("v2", repoV1BoxesFullSet).sortedBy { it.metadata.name }
+        val convertedTh2ResList = Converter.convertFromRequest("v2", repoV1BoxesFullSet)
+            .convertedResources
+            .sortedBy { it.metadata.name }
 
         for ((index, v1Res) in repoV1BoxesFullSet.withIndex()) {
             val resFailMessage = v1Res.metadata.name.plus(" conversion v1 -> v2 failed: ")
@@ -150,7 +152,7 @@ internal class ConverterTest {
         val sampleResSet = setOf(scriptV1, links1, links2)
 
         val failMessage = "script conversion v1 -> v2 failed"
-        val actualConvertedList = Converter.convertFromRequest("v2", sampleResSet)
+        val actualConvertedList = Converter.convertFromRequest("v2", sampleResSet).convertedResources
         val actualConvertedScript = actualConvertedList
             .find { it.metadata.name == "script" } as Th2Resource
         var expectedConvertedScriptSpec: GenericBoxSpec? = null
@@ -195,7 +197,7 @@ internal class ConverterTest {
      */
     @Test
     fun testServiceConversionToV2FromRequest() {
-        val convertedResList = Converter.convertFromRequest("v2", setOf(actV1, fixServerV1))
+        val convertedResList = Converter.convertFromRequest("v2", setOf(actV1, fixServerV1)).convertedResources
         val convertedResMap = convertedResList.associateBy { it.metadata.name }
         val actSpec = convertedResMap["act"]?.spec as GenericBoxSpec
         val actualActService = YAML_MAPPER.writeValueAsString(actSpec.extendedSettings?.service)
@@ -237,7 +239,7 @@ internal class ConverterTest {
         val repoV1AllResourcesSet = HashSet(repoV1BoxesFullSet)
         repoV1AllResourcesSet.add(links1)
         repoV1AllResourcesSet.add(links2)
-        val convertedResList = Converter.convertFromRequest("v2", repoV1AllResourcesSet)
+        val convertedResList = Converter.convertFromRequest("v2", repoV1AllResourcesSet).convertedResources
         val convertedResMap = convertedResList.associateBy { it.metadata.name }
 
         val actualFixServerSpec = convertedResMap["fix-server"]?.spec as GenericBoxSpec


### PR DESCRIPTION
Modify API in a way that `convertRequestedResources` also returns the summary of conversion(as Git-related API endpoints do), in addition to converted resources in HTTP response.